### PR TITLE
`STDIN_SOURCE` does not need to be used directly

### DIFF
--- a/verify/src/bin/hash_lsm_tree_test.rs
+++ b/verify/src/bin/hash_lsm_tree_test.rs
@@ -4,29 +4,24 @@ use ralgo::data_structure::hash_lsm_tree::HashLSMTree;
 // verify-helper: PROBLEM https://judge.yosupo.jp/problem/associative_array
 
 fn main() {
-    let mut source = proconio::STDIN_SOURCE.lock().unwrap();
     input! {
-        from &mut *source,
-        q: usize
+        q: usize,
     };
 
     let mut tree = HashLSMTree::new();
 
     for _ in 0..q {
         input! {
-            from &mut *source,
-            q_type: usize
+            q_type: usize,
         }
         if q_type == 0 {
             input! {
-                from &mut *source,
                 k: usize,
                 v: usize,
             }
             tree.insert(k, v);
         } else {
             input! {
-                from &mut *source,
                 k: usize,
             }
             println!("{}", tree.get(&k).unwrap_or(&0));

--- a/verify/src/bin/hash_radix_tree_test.rs
+++ b/verify/src/bin/hash_radix_tree_test.rs
@@ -4,29 +4,24 @@ use ralgo::data_structure::hash_radix_tree::HashRadixTree;
 // verify-helper: PROBLEM https://judge.yosupo.jp/problem/associative_array
 
 fn main() {
-    let mut source = proconio::STDIN_SOURCE.lock().unwrap();
     input! {
-        from &mut *source,
-        q: usize
+        q: usize,
     };
 
     let mut tree = HashRadixTree::new();
 
     for _ in 0..q {
         input! {
-            from &mut *source,
-            q_type: usize
+            q_type: usize,
         }
         if q_type == 0 {
             input! {
-                from &mut *source,
                 k: usize,
                 v: usize,
             }
             tree.insert(k, v);
         } else {
             input! {
-                from &mut *source,
                 k: usize,
             }
             println!("{}", tree.get(&k).unwrap_or(&0));


### PR DESCRIPTION
`from &mut *source`の部分ですが、このように指定しなくても同じ`AutoSource`が呼ばれ続けます。 (そのための`lazy_static!` & `Mutex`です)

`{Auto, Once, Line}Source`を指定したければこのようにすれば良いです。

[rust-lang-ja/atcoder-rust-base:ja-all-enabled/examples/practice-b-proconio.rs](https://github.com/rust-lang-ja/atcoder-rust-base/blob/ja-all-enabled/examples/practice-b-proconio.rs)